### PR TITLE
Paper Benchmark

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use ark_serialize::*;
 use ark_std::{end_timer, println, rand::Rng, start_timer, vec, UniformRand, Zero};
-use jf_utils::Vec;
+use jf_utils::{to_bytes, Vec};
 use std::time::Instant;
 
 #[test]
@@ -34,6 +34,11 @@ fn dpc_bench() -> Result<(), DPCApiError> {
 
     let inner_srs = crate::proofs::universal_setup_inner(max_inner_degree, rng)?;
     let outer_srs = crate::proofs::universal_setup_outer(max_outer_degree, rng)?;
+    println!(
+        "ℹ️️ inner_srs size: {} bytes, outer_srs size: {} bytes",
+        to_bytes!(&inner_srs).unwrap().len(),
+        to_bytes!(&outer_srs).unwrap().len()
+    );
 
     println!(
         "⏱️ DPC::Setup::universal (inner_max_deg: {}, outer_max_deg: {}) takes {} ms",
@@ -64,6 +69,10 @@ fn zcash_transaction_full_cycle(
 
     let (dpc_pk, dpc_vk, mut birth_predicate, birth_pid, mut death_predicate, death_pid) =
         ZcashPredicate::preprocess(&inner_srs, &outer_srs, num_inputs)?;
+    println!(
+        "ℹ️️ indexed DPC vk size: {} bytes",
+        to_bytes!(&dpc_vk).unwrap().len(),
+    );
 
     println!(
         "⏱️ DPC::Setup::circuit-specific takes {} ms",
@@ -145,6 +154,12 @@ fn zcash_transaction_full_cycle(
 
     let input_death_predicates = vec![death_predicate.0; num_inputs];
     let output_birth_predicates = vec![birth_predicate.0; num_inputs];
+    println!(
+        "ℹ️️ indexed predicate vk size: {} bytes",
+        to_bytes!(input_death_predicates[0].predicate.verify_key_ref())
+            .unwrap()
+            .len(),
+    );
 
     let aggregate_auth_key = {
         let auth_keys = vec![ak.0; num_inputs];

--- a/src/proofs/transaction.rs
+++ b/src/proofs/transaction.rs
@@ -55,7 +55,7 @@ pub struct DPCProvingKey<'a> {
     pub(crate) beta_g: InnerG1Affine,
 }
 
-#[derive(Clone, Debug, PartialEq)] // TODO: derive hash and serialize/deserialize
+#[derive(Clone, Debug, PartialEq, CanonicalSerialize)] // TODO: derive hash and serialize/deserialize
 /// DPC Transaction verifying key
 pub struct DPCVerifyingKey {
     utxo_verifying_key: UtxoVerifyingKey,


### PR DESCRIPTION
**This is NOT meant to be merged into `main` branch!**

I have added support for benchmarking 2~5 input/output transactions, here's the result:

```
⏱️ DPC::Setup::universal (inner_max_deg: 65540, outer_max_deg: 131076) takes 5058 ms
⏱️ DPC::Setup::universal (inner_max_deg: 131076, outer_max_deg: 262148) takes 9421 ms

ℹ️ num of inputs/outputs: 2
ℹ️ num_constraint of (unpadded) UTXO circuit: 36749
ℹ️ num_constraint of (unpadded) outer circuit: 87176
ℹ️ num_constraint of UTXO circuit: 65536, of outer circuit: 87176
⏱️ DPC::Setup::circuit-specific takes 58384 ms
ℹ️ birth predicate size: 32768; death predicate size: 32768
⏱️ DPC::GenAddress takes 1 ms
⏱️ all 4 predicate proofs gen takes: 4829 ms
⏱️️ UTXO proof gen takes: 5477 ms
⏱️ Outer proof gen takes: 58846 ms
ℹ️ txn_note size: 4738 bytes; txn proof size: 4138 bytes
⏱️ DPC::Execute takes 69682 ms
⏱️ DPC::Verify takes 21 ms

ℹ️ num of inputs/outputs: 3
ℹ️ num_constraint of (unpadded) UTXO circuit: 54138
ℹ️ num_constraint of (unpadded) outer circuit: 126076
ℹ️ num_constraint of UTXO circuit: 65536, of outer circuit: 126076
⏱️ DPC::Setup::circuit-specific takes 105235 ms
ℹ️ birth predicate size: 32768; death predicate size: 32768
⏱️ DPC::GenAddress takes 1 ms
⏱️ all 6 predicate proofs gen takes: 6787 ms
⏱️️ UTXO proof gen takes: 5473 ms
⏱️ Outer proof gen takes: 116658 ms
ℹ️ txn_note size: 4802 bytes; txn proof size: 4138 bytes
⏱️ DPC::Execute takes 129625 ms
⏱️ DPC::Verify takes 21 ms

ℹ️ num of inputs/outputs: 4
ℹ️ num_constraint of (unpadded) UTXO circuit: 71527
ℹ️ num_constraint of (unpadded) outer circuit: 141492
ℹ️ num_constraint of UTXO circuit: 131072, of outer circuit: 141492
⏱️ DPC::Setup::circuit-specific takes 110687 ms
ℹ️ birth predicate size: 65536; death predicate size: 65536
⏱️ DPC::GenAddress takes 1 ms
⏱️ all 8 predicate proofs gen takes: 16771 ms
⏱️️ UTXO proof gen takes: 10970 ms
⏱️ Outer proof gen takes: 117627 ms
ℹ️ txn_note size: 4866 bytes; txn proof size: 4138 bytes
⏱️ DPC::Execute takes 146323 ms
⏱️ DPC::Verify takes 21 ms

ℹ️ num of inputs/outputs: 5
ℹ️ num_constraint of (unpadded) UTXO circuit: 89308
ℹ️ num_constraint of (unpadded) outer circuit: 180544
ℹ️ num_constraint of UTXO circuit: 131072, of outer circuit: 180544
⏱️ DPC::Setup::circuit-specific takes 116749 ms
ℹ️ birth predicate size: 65536; death predicate size: 65536
⏱️ DPC::GenAddress takes 1 ms
⏱️ all 10 predicate proofs gen takes: 20315 ms
⏱️️ UTXO proof gen takes: 11101 ms
⏱️ Outer proof gen takes: 116825 ms
ℹ️ txn_note size: 4930 bytes; txn proof size: 4138 bytes
⏱️ DPC::Execute takes 149421 ms
⏱️ DPC::Verify takes 21 ms

```
